### PR TITLE
go api: use byte slices for deck parsing - reuse deck parsing results for subsequent reqs

### DIFF
--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -17,7 +17,7 @@ type API struct {
 	users       *slaytherelics.Users
 	broadcaster *slaytherelics.Broadcaster
 
-	deckLists map[string]string
+	deckLists map[string]*deck
 	deckLock  *sync.RWMutex
 }
 
@@ -36,7 +36,7 @@ func New(t *client.Twitch, u *slaytherelics.Users, b *slaytherelics.Broadcaster)
 		twitch:      t,
 		users:       u,
 		broadcaster: b,
-		deckLists:   make(map[string]string),
+		deckLists:   make(map[string]*deck),
 		deckLock:    &sync.RWMutex{},
 	}
 

--- a/backend/api/api_test.go
+++ b/backend/api/api_test.go
@@ -1,0 +1,39 @@
+package api
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// TODO: stub for external clients, redis docker container in CI, tests for other endpoints
+
+func TestDeckAPIHandler(t *testing.T) {
+	router, err := New(nil, nil, nil)
+	assert.NilError(t, err)
+
+	testName := "testdeck" // TODO: UUID pkg for stuff like this
+
+	// TODO: seed data with actual test data
+	bigDeckStr := getBigDeckString()
+
+	router.deckLists[testName] = &deck{buf: []byte(bigDeckStr)}
+
+	stableMap, err := decompressDeck(bigDeckStr)
+	assert.NilError(t, err)
+
+	expectedOutput := getStableOutput(stableMap)
+
+	handlerFn := router.Router.Handler()
+
+	httpReq := httptest.NewRequest("GET", "/deck/"+testName, nil)
+
+	w := httptest.NewRecorder()
+
+	handlerFn.ServeHTTP(w, httpReq)
+
+	assert.Equal(t, w.Code, 200, w.Body.String())
+
+	assert.Equal(t, w.Body.String(), expectedOutput)
+}

--- a/backend/api/api_test.go
+++ b/backend/api/api_test.go
@@ -27,13 +27,26 @@ func TestDeckAPIHandler(t *testing.T) {
 
 	handlerFn := router.Router.Handler()
 
-	httpReq := httptest.NewRequest("GET", "/deck/"+testName, nil)
+	checkTestDeck := func() {
+		httpReq := httptest.NewRequest("GET", "/deck/"+testName, nil)
 
-	w := httptest.NewRecorder()
+		w := httptest.NewRecorder()
 
-	handlerFn.ServeHTTP(w, httpReq)
+		handlerFn.ServeHTTP(w, httpReq)
 
-	assert.Equal(t, w.Code, 200, w.Body.String())
+		assert.Equal(t, w.Code, 200, w.Body.String())
 
-	assert.Equal(t, w.Body.String(), expectedOutput)
+		assert.Equal(t, w.Body.String(), expectedOutput)
+	}
+
+	deckBuf := router.deckLists[testName].buf
+	assert.DeepEqual(t, string(deckBuf), bigDeckStr)
+
+	checkTestDeck()
+
+	// make sure that the decks parse result gets reused
+	deckBuf = router.deckLists[testName].buf
+	assert.DeepEqual(t, string(deckBuf), expectedOutput)
+
+	checkTestDeck()
 }

--- a/backend/api/deck.go
+++ b/backend/api/deck.go
@@ -84,6 +84,19 @@ func (d *deck) parse() error {
 
 	parts := bytes.Split(decompressed, []byte(";;;"))
 
+	if len(parts) != 2 {
+		return errors.New("invalid deck")
+	}
+
+	if len(parts[0]) == 1 && parts[0][0] == '-' {
+		// d.buf = []byte("No cards in deck")
+		return nil
+	}
+	if len(parts[1]) == 1 && parts[1][0] == '-' {
+		// d.buf = []byte("No cards in deck")
+		return nil
+	}
+
 	// read cards first so we can reference them as we read the card indexes
 	cards := make([][]byte, 0, bytes.Count(parts[1], []byte(";;"))+1)
 	longestCard := 0
@@ -118,7 +131,7 @@ func (d *deck) parse() error {
 		}
 
 		card := parseCardBytes(cards[cardIdxVal])
-		fmt.Printf("%d - %s - %s\n", cardIdxVal, string(card), string(cards[cardIdxVal]))
+		// fmt.Printf("%d - %s - %s\n", cardIdxVal, string(card), string(cards[cardIdxVal]))
 
 		if len(card) == 0 {
 			return nil
@@ -169,10 +182,6 @@ func (d *deck) parse() error {
 			d.buf = strconv.AppendInt(d.buf, int64(cardCount), 10)
 			d.buf = append(d.buf, '\n')
 		}
-	}
-
-	if len(d.buf) < cap(d.buf) {
-		d.buf = d.buf[:len(d.buf)]
 	}
 
 	return nil

--- a/backend/api/deck.go
+++ b/backend/api/deck.go
@@ -85,6 +85,19 @@ type deck struct {
 	parseOnce sync.Once
 }
 
+// Bytes use to get parsed deck
+func (d *deck) Bytes() (res []byte, err error) {
+	d.parseOnce.Do(func() {
+		err = d.parse() // if this fails once, it will fail every time
+	})
+	return d.buf, err
+}
+
+// parse
+func (d *deck) parse() error {
+	return nil
+}
+
 func decompress(s string) (string, error) {
 	parts := strings.Split(s, "||")
 	if len(parts) < 2 {

--- a/backend/api/deck.go
+++ b/backend/api/deck.go
@@ -54,6 +54,8 @@ func (a *API) getDeckHandler(c *gin.Context) {
 	c.Data(200, "text/plain", resBts)
 }
 
+// region deck parsing unstable
+
 // deck designed to be parsed once and then used for lookups. The load of the parsing is in the request context as to
 // not block the sub
 type deck struct {
@@ -229,6 +231,10 @@ func parseCardBytes(cardSection []byte) []byte {
 	return cardSection[:sectionEnd]
 }
 
+// endregion
+
+// region stable parse logic
+
 func decompress(s string) (string, error) {
 	parts := strings.Split(s, "||")
 	if len(parts) < 2 {
@@ -319,3 +325,5 @@ func decompressDeck(deck string) (map[string]int, error) {
 
 	return deckDict, nil
 }
+
+// endregion

--- a/backend/api/deck.go
+++ b/backend/api/deck.go
@@ -187,6 +187,7 @@ func decompressBytes(s []byte) ([]byte, error) {
 
 	for i := len(compressionDict) - 1; i >= 0; i-- {
 		word := compressionDict[i]
+		// TODO: this is the source of lots of allocs and CPU cycles, probably no need for regexp here
 		text = compressionWildcardRegex[i].ReplaceAll(text, word)
 	}
 

--- a/backend/api/deck_test.go
+++ b/backend/api/deck_test.go
@@ -2,9 +2,11 @@ package api
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
+	"golang.org/x/exp/slices"
 	"gotest.tools/v3/assert"
 )
 
@@ -70,11 +72,18 @@ func TestDecompress(t *testing.T) {
 			actualOutput, err := decompress(tc.input)
 			if tc.shouldError {
 				assert.Equal(t, true, err != nil)
+				_, err = decompressBytes([]byte(tc.input))
+				assert.Equal(t, true, err != nil)
 				return
 			}
 
 			assert.NilError(t, err)
 			assert.Equal(t, actualOutput, tc.output)
+
+			unstableOut, err := decompressBytes([]byte(tc.input))
+			assert.NilError(t, err)
+
+			assert.Equal(t, string(unstableOut), tc.output)
 		})
 	}
 }
@@ -131,6 +140,128 @@ func TestParseCommaDelimitedIntegerArray(t *testing.T) {
 			for i := range actualOutput {
 				assert.Equal(t, actualOutput[i], tc.output[i])
 			}
+		})
+	}
+}
+
+func TestReadDelemitedBytesIntArrs(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		input       string
+		output      []int
+		shouldError bool
+	}{
+		{
+			desc:        "Empty",
+			input:       "",
+			output:      []int{},
+			shouldError: false,
+		},
+		{
+			desc:        "Dash",
+			input:       "-",
+			output:      []int{},
+			shouldError: false,
+		},
+		{
+			desc:        "Invalid",
+			input:       "{",
+			output:      []int{},
+			shouldError: true,
+		},
+		{
+			desc:        "Single",
+			input:       "19",
+			output:      []int{19},
+			shouldError: false,
+		},
+		{
+			desc:        "Many",
+			input:       "1,2,3,4,5,6,7,8,9,1,2,3,4,5,6,7,8,9",
+			output:      []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			shouldError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			result := make([]int, 0, len(tc.output))
+			err := readDelimitedBytes([]byte(tc.input), []byte(","), func(val []byte) error {
+				valInt, err := strconv.ParseInt(string(val), 10, 64)
+				if err != nil {
+					return err
+				}
+
+				result = append(result, int(valInt))
+
+				return nil
+			})
+			if tc.shouldError {
+				assert.Equal(t, true, err != nil)
+				return
+			}
+
+			assert.NilError(t, err)
+
+			assert.DeepEqual(t, result, tc.output)
+		})
+	}
+}
+
+func TestReadDelemitedBytesSplitStringMultiCharDelim(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		input       string
+		delim       string
+		output      []string
+		shouldError bool
+	}{
+		{
+			desc:        "Empty",
+			input:       "",
+			delim:       ";;",
+			output:      []string{},
+			shouldError: false,
+		},
+		{
+			desc:        "Dash",
+			input:       "-",
+			delim:       ";;",
+			output:      []string{},
+			shouldError: false,
+		},
+		{
+			desc:        "Single",
+			input:       "love slay the spire",
+			delim:       ";;",
+			output:      []string{"love slay the spire"},
+			shouldError: false,
+		},
+		{
+			desc:        "Many",
+			input:       "slay;;the;;spire;;is;;an;;awesome;;game,and;;I;;love;;it;;because;;it;;is;;an;;interesting;;game",
+			delim:       ";;",
+			output:      []string{"slay", "the", "spire", "is", "an", "awesome", "game,and", "I", "love", "it", "because", "it", "is", "an", "interesting", "game"},
+			shouldError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			result := make([]string, 0, len(tc.output))
+			err := readDelimitedBytes([]byte(tc.input), []byte(tc.delim), func(val []byte) error {
+				result = append(result, string(val))
+
+				return nil
+			})
+			if tc.shouldError {
+				assert.Equal(t, true, err != nil)
+				return
+			}
+
+			assert.NilError(t, err)
+
+			assert.DeepEqual(t, result, tc.output)
 		})
 	}
 }
@@ -195,6 +326,80 @@ func TestDecompressDeck(t *testing.T) {
 	}
 }
 
+func TestDecompressDeckUnstable(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		input       string
+		output      map[string]int
+		shouldError bool
+	}{
+		{
+			desc:        "Empty",
+			input:       "",
+			output:      map[string]int{},
+			shouldError: true,
+		},
+		{
+			desc:        "Invalid card index",
+			input:       "card|junk||};;;&01;&1;x;;&02;&1;y;;&03;&1;z",
+			output:      map[string]int{},
+			shouldError: true,
+		},
+		{
+			desc:        "Negative card index",
+			input:       "card|junk||-1;;;&01;&1;x;;&02;&1;y;;&03;&1;z",
+			output:      map[string]int{},
+			shouldError: true,
+		},
+		{
+			desc:        "Out of bounds card index",
+			input:       "card|junk||3;;;&01;&1;x;;&02;&1;y;;&03;&1;z",
+			output:      map[string]int{},
+			shouldError: true,
+		},
+		{
+			desc:  "Simple deck",
+			input: "card|junk||0,1,1,0,2,0;;;&01;&1;x;;&02;&1;y;;&03;&1;z",
+			output: map[string]int{
+				"card1": 3,
+				"card2": 2,
+				"card3": 1,
+			},
+			shouldError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			d := &deck{
+				buf: []byte(tc.input),
+			}
+
+			actualOutput, err := decompressDeck(tc.input)
+			if tc.shouldError {
+				assert.Equal(t, true, err != nil)
+
+				_, err = d.Bytes()
+				assert.Equal(t, true, err != nil)
+				return
+			}
+
+			assert.NilError(t, err)
+			assert.Equal(t, len(actualOutput), len(tc.output))
+			for i := range actualOutput {
+				assert.Equal(t, actualOutput[i], tc.output[i])
+			}
+
+			stableOut := getStableOutput(actualOutput)
+
+			unstableOut, err := d.Bytes()
+			assert.NilError(t, err)
+
+			assert.Equal(t, string(unstableOut), stableOut)
+		})
+	}
+}
+
 // getBigDeckString makes us a 52 card compressed deck string for testing with.
 func getBigDeckString() string {
 	compressionDict := make([]string, 0, 128)
@@ -238,6 +443,52 @@ func TestDecompressBigDeck(t *testing.T) {
 	}
 }
 
+// old handler code for formatting result
+func getStableOutput(countMap map[string]int) string {
+	keys := make([]string, 0, len(countMap))
+	for k := range countMap {
+		keys = append(keys, k)
+	}
+
+	slices.SortFunc(keys, func(i, j string) bool {
+		if i == "Ascender's Bane" {
+			return false
+		}
+		if j == "Ascender's Bane" {
+			return true
+		}
+		return i < j
+	})
+
+	result := strings.Builder{}
+	for _, k := range keys {
+		result.WriteString(k)
+		result.WriteString(" x")
+		result.WriteString(fmt.Sprint(countMap[k]))
+		result.WriteString("\n")
+	}
+
+	return result.String()
+}
+
+func TestDecompressBigDeckUnstable(t *testing.T) {
+	deckStr := getBigDeckString()
+
+	res, err := decompressDeck(deckStr)
+	assert.NilError(t, err)
+
+	stableOutput := getStableOutput(res)
+
+	deck := &deck{
+		buf: []byte(deckStr),
+	}
+
+	unstableOut, err := deck.Bytes()
+	assert.NilError(t, err)
+
+	assert.Equal(t, string(unstableOut), stableOutput)
+}
+
 func BenchmarkDecompressDeck(b *testing.B) {
 	testCases := []struct {
 		desc  string
@@ -258,6 +509,33 @@ func BenchmarkDecompressDeck(b *testing.B) {
 		b.Run(tc.desc, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				decompressDeck(tc.input)
+			}
+		})
+	}
+}
+
+func BenchmarkDecompressDeckUnstable(b *testing.B) {
+	testCases := []struct {
+		desc  string
+		input []byte
+	}{
+		{
+			desc:  "Simple deck",
+			input: []byte("card|junk||0,1,1,0,2,0;;;&01;&1;x;;&02;&1;y;;&03;&1;z"),
+		},
+		{
+			desc:  "Big deck",
+			input: []byte(getBigDeckString()),
+		},
+	}
+
+	d := new(deck)
+	b.ResetTimer()
+	for _, tc := range testCases {
+		b.Run(tc.desc, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				d.buf = tc.input
+				d.parse()
 			}
 		})
 	}

--- a/backend/api/message.go
+++ b/backend/api/message.go
@@ -55,7 +55,10 @@ func (a *API) postMessageHandler(c *gin.Context) {
 		func() {
 			a.deckLock.Lock()
 			defer a.deckLock.Unlock()
-			a.deckLists[strings.ToLower(user.Login)] = message["k"].(string)
+			a.deckLists[strings.ToLower(user.Login)] = &deck{
+				// copy is fine here, since otherwise this context would own this byte slice and produce the same effect
+				buf: []byte(message["k"].(string)),
+			}
 		}()
 	}
 	err = a.broadcast(c, ctx, req, user.ID, message)

--- a/backend/o11y/middleware.go
+++ b/backend/o11y/middleware.go
@@ -7,11 +7,15 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// nil checks for Tracer and Meter are included for api handler tests (for now)
 func Middleware(c *gin.Context) {
 	var err error
-
-	ctx, span := Tracer.Start(c.Request.Context(), "http.request", trace.WithSpanKind(trace.SpanKindServer))
-	defer End(&span, &err)
+	ctx := c.Request.Context()
+	var span trace.Span
+	if Tracer != nil {
+		ctx, span = Tracer.Start(c.Request.Context(), "http.request", trace.WithSpanKind(trace.SpanKindServer))
+		defer End(&span, &err)
+	}
 
 	req := c.Request.WithContext(ctx)
 	c.Request = req
@@ -20,41 +24,47 @@ func Middleware(c *gin.Context) {
 	method := req.Method
 	contentLength := req.ContentLength
 
-	span.SetAttributes(
-		attribute.String("http.url", req.URL.String()),
-		attribute.String("http.target", target),
-		attribute.String("http.method", method),
-		attribute.String("http.user_agent", req.UserAgent()),
-		attribute.String("http.host", req.Host),
-		attribute.String("http.scheme", req.URL.Scheme),
-		attribute.Int64("http.request_content_length", contentLength),
-	)
+	if span != nil {
+		span.SetAttributes(
+			attribute.String("http.url", req.URL.String()),
+			attribute.String("http.target", target),
+			attribute.String("http.method", method),
+			attribute.String("http.user_agent", req.UserAgent()),
+			attribute.String("http.host", req.Host),
+			attribute.String("http.scheme", req.URL.Scheme),
+			attribute.Int64("http.request_content_length", contentLength),
+		)
+	}
 
 	c.Next()
 
 	err = c.Err()
 	status := c.Writer.Status()
 
-	requestCounter, _ := Meter.Int64Counter("http.requests")
-	requestHistogram, _ := Meter.Int64Histogram("http.requests.content_length")
-	if requestCounter != nil {
-		requestCounter.Add(ctx, 1,
-			metric.WithAttributes(
-				attribute.String("target", target),
-				attribute.String("method", method),
-				attribute.Int("status_code", status),
-			),
-		)
-	}
-	if requestHistogram != nil {
-		requestHistogram.Record(ctx, contentLength,
-			metric.WithAttributes(
-				attribute.String("target", target),
-				attribute.String("method", method),
-				attribute.Int("status_code", status),
-			),
-		)
+	if Meter != nil {
+		requestCounter, _ := Meter.Int64Counter("http.requests")
+		requestHistogram, _ := Meter.Int64Histogram("http.requests.content_length")
+		if requestCounter != nil {
+			requestCounter.Add(ctx, 1,
+				metric.WithAttributes(
+					attribute.String("target", target),
+					attribute.String("method", method),
+					attribute.Int("status_code", status),
+				),
+			)
+		}
+		if requestHistogram != nil {
+			requestHistogram.Record(ctx, contentLength,
+				metric.WithAttributes(
+					attribute.String("target", target),
+					attribute.String("method", method),
+					attribute.Int("status_code", status),
+				),
+			)
+		}
 	}
 
-	span.SetAttributes(attribute.Int("http.status_code", status))
+	if span != nil {
+		span.SetAttributes(attribute.Int("http.status_code", status))
+	}
 }


### PR DESCRIPTION
As listed in [this pull request](https://github.com/MaT1g3R/slay-the-relics/pull/19), the optimization can be taken a bit further.

Added deck struct to manage parsing logic.
Converted string parsing functions into their byte counterparts.
Added functionality for reusing parsed deck data between reqs.

Added tests for the bytes deck parsing logic (left the old for now, but can remove have just been using for comparisons for now).
Added tests for the deck API handler (bumped up coverage by a bit)

Do not have as good of a computer for the benchmarks, but here is the comparison from my machine:

```
goos: windows
goarch: amd64
pkg: github.com/MaT1g3R/slaytherelics/api
cpu: AMD Ryzen 7 3800XT 8-Core Processor
                              │   old.out    │               new.out                │
                              │    sec/op    │    sec/op     vs base                │
DecompressDeck/Simple_deck-16   1.947µ ± ∞ ¹   2.224µ ± ∞ ¹       ~ (p=1.000 n=1) ²
DecompressDeck/Big_deck-16      74.90µ ± ∞ ¹   59.58µ ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                         12.08µ         11.51µ        -4.68%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                              │    old.out    │                new.out                 │
                              │     B/op      │     B/op       vs base                 │
DecompressDeck/Simple_deck-16     841.0 ± ∞ ¹     554.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
DecompressDeck/Big_deck-16      220.5Ki ± ∞ ¹   116.4Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                         13.46Ki         7.935Ki        -41.04%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                              │   old.out   │               new.out                │
                              │  allocs/op  │  allocs/op   vs base                 │
DecompressDeck/Simple_deck-16   17.00 ± ∞ ¹   15.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
DecompressDeck/Big_deck-16      165.0 ± ∞ ¹   112.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                         52.96         40.99        -22.61%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
```

Unsure of why the small deck is faster as of writing this, but the main change I wanted to implement was reuse of the request results.

Seems like even in the "large deck" cases we end up not storing that much in the decompressed buffer, was <2Kb for the large case per-item.